### PR TITLE
Simplify and improve deployment info forms

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>K8S RPi Pipeline Interface</title>
+    <title>K8s RPi Pipeline Interface</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/public/index.js
+++ b/public/index.js
@@ -74,17 +74,16 @@ class DeployService extends React.Component {
     this.state = {
       repoUrl: '',
       repoBranch: '',
-      useRepoConfig: false,
+      useRepoDeployConfig: false,
+      useRepoServiceConfig: false,
       deployConfigPath: '',
       serviceConfigPath: '',
       appName: '',
-      //appTier: '',
-      //appRole: '',
-      containerName: '',
-      containerImage: '',
-      containerPort: '',
-      servicePort: '',
+      imageName: '',
       netProtocol: 'TCP',
+      containerPort: '',
+      openToNetwork: false,
+      nodePort: '',
       replicas: 1
     };
     this.handleChange = this.handleChange.bind(this);
@@ -117,19 +116,20 @@ class DeployService extends React.Component {
 
       if (!res.ok) {
         throw new Error("Status code " + res.status.toString() + " (" + res.statusText + ")\n" + JSON.stringify(body));
-      }
+      } //window.location.reload(true);
 
-      window.location.reload(true);
     } catch (error) {
       alert(error.message);
     }
   }
 
   render() {
-    let configGen;
+    let deployConfigGen;
+    let serviceConfigGen;
+    let networkConfigGen;
 
-    if (!this.state.useRepoConfig) {
-      configGen = /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("label", {
+    if (!this.state.useRepoDeployConfig) {
+      deployConfigGen = /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("label", {
         htmlFor: "appName"
       }, "Application Name:"), /*#__PURE__*/React.createElement("input", {
         type: "text",
@@ -138,38 +138,52 @@ class DeployService extends React.Component {
         value: this.state.appName,
         onChange: this.handleChange
       }), /*#__PURE__*/React.createElement("br", null), /*#__PURE__*/React.createElement("label", {
-        htmlFor: "containerName"
-      }, "Container Name:"), /*#__PURE__*/React.createElement("input", {
+        htmlFor: "imageName"
+      }, "Image Name (leave blank to use the same name):"), /*#__PURE__*/React.createElement("input", {
         type: "text",
-        id: "container-name",
-        name: "containerName",
-        value: this.state.containerName,
+        id: "image-name",
+        name: "imageName",
+        value: this.state.imageName,
         onChange: this.handleChange
       }), /*#__PURE__*/React.createElement("br", null), /*#__PURE__*/React.createElement("label", {
-        htmlFor: "containerImage"
-      }, "Container Image:"), /*#__PURE__*/React.createElement("input", {
-        type: "text",
-        id: "container-image",
-        name: "containerImage",
-        value: this.state.containerImage,
+        htmlFor: "replicas"
+      }, "Number of containers to build:"), /*#__PURE__*/React.createElement("input", {
+        type: "number",
+        id: "replicas",
+        name: "replicas",
+        value: this.state.replicas,
+        min: "1",
+        max: "8",
         onChange: this.handleChange
-      }), /*#__PURE__*/React.createElement("br", null), /*#__PURE__*/React.createElement("label", {
-        htmlFor: "containerPort"
-      }, "Container Port:"), /*#__PURE__*/React.createElement("input", {
+      }));
+    } else {
+      deployConfigGen = /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("label", {
+        htmlFor: "deployConfigPath"
+      }, "Deployment Config Path:"), /*#__PURE__*/React.createElement("input", {
         type: "text",
-        id: "container-port",
-        name: "containerPort",
-        value: this.state.containerPort,
+        id: "deploy-config-path",
+        name: "deployConfigPath",
+        value: this.state.deployConfigPath,
         onChange: this.handleChange
-      }), /*#__PURE__*/React.createElement("br", null), /*#__PURE__*/React.createElement("label", {
-        htmlFor: "servicePort"
-      }, "Service Port:"), /*#__PURE__*/React.createElement("input", {
+      }));
+    }
+
+    if (this.state.openToNetwork) {
+      networkConfigGen = /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("label", {
+        htmlFor: "nodePort"
+      }, "Network Port (must be between 30000-32767, leave blank for random):"), /*#__PURE__*/React.createElement("input", {
         type: "text",
-        id: "service-port",
-        name: "servicePort",
-        value: this.state.servicePort,
+        id: "node-port",
+        name: "nodePort",
+        value: this.state.nodePort,
         onChange: this.handleChange
-      }), /*#__PURE__*/React.createElement("br", null), /*#__PURE__*/React.createElement("label", {
+      }));
+    } else {
+      networkConfigGen = /*#__PURE__*/React.createElement("div", null);
+    }
+
+    if (!this.state.useRepoServiceConfig) {
+      serviceConfigGen = /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("label", {
         htmlFor: "netProtocol"
       }, "Port Protocol:"), /*#__PURE__*/React.createElement("select", {
         id: "net-protocol",
@@ -183,26 +197,24 @@ class DeployService extends React.Component {
       }, "UDP"), /*#__PURE__*/React.createElement("option", {
         value: "SCTP"
       }, "SCTP")), /*#__PURE__*/React.createElement("br", null), /*#__PURE__*/React.createElement("label", {
-        htmlFor: "replicas"
-      }, "Number of containers to build:"), /*#__PURE__*/React.createElement("input", {
-        type: "number",
-        id: "replicas",
-        name: "replicas",
-        value: this.state.replicas,
-        min: "1",
-        max: "8",
-        onChange: this.handleChange
-      }));
-    } else {
-      configGen = /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("label", {
-        htmlFor: "deployConfigPath"
-      }, "Deployment Config Path:"), /*#__PURE__*/React.createElement("input", {
+        htmlFor: "containerPort"
+      }, "Container Port:"), /*#__PURE__*/React.createElement("input", {
         type: "text",
-        id: "deploy-config-path",
-        name: "deployConfigPath",
-        value: this.state.deployConfigPath,
+        id: "container-port",
+        name: "containerPort",
+        value: this.state.containerPort,
         onChange: this.handleChange
-      }), /*#__PURE__*/React.createElement("br", null), /*#__PURE__*/React.createElement("label", {
+      }), /*#__PURE__*/React.createElement("br", null), /*#__PURE__*/React.createElement("input", {
+        type: "checkbox",
+        id: "open-to-network",
+        name: "openToNetwork",
+        checked: this.state.openToNetwork,
+        onChange: this.handleChange
+      }), /*#__PURE__*/React.createElement("label", {
+        htmlFor: "openToNetwork"
+      }, "Open to port on network"), /*#__PURE__*/React.createElement("br", null), networkConfigGen);
+    } else {
+      serviceConfigGen = /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("label", {
         htmlFor: "serviceConfigPath"
       }, "Service Config Path:"), /*#__PURE__*/React.createElement("input", {
         type: "text",
@@ -219,7 +231,9 @@ class DeployService extends React.Component {
     }, /*#__PURE__*/React.createElement("h2", null, "Deploy New Service"), /*#__PURE__*/React.createElement("form", {
       id: "deploy-form",
       onSubmit: this.handleSubmit
-    }, /*#__PURE__*/React.createElement("label", {
+    }, /*#__PURE__*/React.createElement("h3", {
+      className: "form-header"
+    }, "Image"), /*#__PURE__*/React.createElement("label", {
       htmlFor: "repoUrl"
     }, "GitHub Repository URL:"), /*#__PURE__*/React.createElement("input", {
       type: "text",
@@ -235,15 +249,27 @@ class DeployService extends React.Component {
       name: "repoBranch",
       value: this.state.repoBranch,
       onChange: this.handleChange
-    }), /*#__PURE__*/React.createElement("br", null), /*#__PURE__*/React.createElement("input", {
+    }), /*#__PURE__*/React.createElement("br", null), /*#__PURE__*/React.createElement("h3", {
+      className: "form-header"
+    }, "Deployment Configuration"), /*#__PURE__*/React.createElement("input", {
       type: "checkbox",
-      id: "use-config",
-      name: "useRepoConfig",
-      checked: this.state.useRepoConfig,
+      id: "use-repo-deploy-config",
+      name: "useRepoDeployConfig",
+      checked: this.state.useRepoDeployConfig,
       onChange: this.handleChange
     }), /*#__PURE__*/React.createElement("label", {
       htmlFor: "useRepoConfig"
-    }, "Use repository K8s configuration"), /*#__PURE__*/React.createElement("br", null), configGen, /*#__PURE__*/React.createElement("input", {
+    }, "Use repository K8s deployment config file"), /*#__PURE__*/React.createElement("br", null), deployConfigGen, /*#__PURE__*/React.createElement("h3", {
+      className: "form-header"
+    }, "Service Configuration"), /*#__PURE__*/React.createElement("input", {
+      type: "checkbox",
+      id: "use-repo-service-config",
+      name: "useRepoServiceConfig",
+      checked: this.state.useRepoServiceConfig,
+      onChange: this.handleChange
+    }), /*#__PURE__*/React.createElement("label", {
+      htmlFor: "useRepoConfig"
+    }, "Use repository K8s service config file"), /*#__PURE__*/React.createElement("br", null), serviceConfigGen, /*#__PURE__*/React.createElement("input", {
       type: "submit",
       id: "deploy-form-submit",
       value: "Deploy"

--- a/public/index.js
+++ b/public/index.js
@@ -1,14 +1,8 @@
-class LogoutButton extends React.Component {
-  render() {
-    return /*#__PURE__*/React.createElement("button", {
-      id: "logout-button",
-      name: "logout",
-      type: "button"
-    }, "Logout");
-  }
-
-}
-
+/*class LogoutButton extends React.Component {
+    render() {
+        return <button id="logout-button" name="logout" type="button">Logout</button>
+    }
+}*/
 class Header extends React.Component {
   render() {
     return /*#__PURE__*/React.createElement("div", {
@@ -17,9 +11,7 @@ class Header extends React.Component {
       className: "title"
     }, /*#__PURE__*/React.createElement("h1", {
       className: "title-text"
-    }, "[Name Pending]")), /*#__PURE__*/React.createElement("div", {
-      className: "logout"
-    }, /*#__PURE__*/React.createElement(LogoutButton, null)));
+    }, "KubePi Pipeline")));
   }
 
 }
@@ -55,15 +47,7 @@ class Sidebar extends React.Component {
       name: "manage-services",
       type: "button",
       onClick: this.handleClick
-    }, "Manage Services")), /*#__PURE__*/React.createElement("li", {
-      className: "sidebar-tab"
-    }, /*#__PURE__*/React.createElement("button", {
-      className: this.props.activeContent == "admin-settings" ? "active sidebar-option" : "sidebar-option",
-      id: "admin-settings-button",
-      name: "admin-settings",
-      type: "button",
-      onClick: this.handleClick
-    }, "Admin Settings"))));
+    }, "Manage Services"))));
   }
 
 }
@@ -79,7 +63,9 @@ class DeployService extends React.Component {
       deployConfigPath: '',
       serviceConfigPath: '',
       appName: '',
+      // tempAppName: '',
       imageName: '',
+      tempImageName: '',
       netProtocol: 'TCP',
       containerPort: '',
       openToNetwork: false,
@@ -93,7 +79,17 @@ class DeployService extends React.Component {
   handleChange(event) {
     const target = event.target;
     const value = target.type === 'checkbox' ? target.checked : target.value;
-    const name = target.name;
+    const name = target.name; // if (name == "repoURL") {
+    //     newName = value.slice(19, value.length - 5);
+    //     this.setState({tempAppName: newName, tempImageName: newName + ":latest"});
+    // }
+
+    if (name == "appName") {
+      this.setState({
+        tempImageName: value + ":latest"
+      });
+    }
+
     this.setState({
       [name]: value
     });
@@ -101,6 +97,14 @@ class DeployService extends React.Component {
 
   async handleSubmit(event) {
     event.preventDefault();
+    document.getElementById("overlay").style.display = "block";
+    document.getElementById("modal").style.display = "block"; // if (this.state.appName == '') {
+    //     this.setState({appName: this.state.tempAppName});
+    // }
+    // if (this.state.imageName == '') {
+    //     this.setState({imageName: this.state.tempImageName});
+    // }
+
     let url = window.location.href + 'deploy';
     let requestOptions = {
       method: 'POST',
@@ -117,10 +121,14 @@ class DeployService extends React.Component {
       if (!res.ok) {
         throw new Error("Status code " + res.status.toString() + " (" + res.statusText + ")\n" + JSON.stringify(body));
       } else {
+        document.getElementById("overlay").style.display = "none";
+        document.getElementById("modal").style.display = "none";
         alert("Deployment created!");
       } //window.location.reload(true);
 
     } catch (error) {
+      document.getElementById("overlay").style.display = "none";
+      document.getElementById("modal").style.display = "none";
       alert(error.message);
     }
   }
@@ -130,25 +138,33 @@ class DeployService extends React.Component {
     let serviceConfigGen;
 
     if (!this.state.useRepoDeployConfig) {
-      deployConfigGen = /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("label", {
+      deployConfigGen = /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("div", {
+        className: "form-input"
+      }, /*#__PURE__*/React.createElement("label", {
+        className: "required-field",
         htmlFor: "appName"
-      }, "Application Name:"), /*#__PURE__*/React.createElement("input", {
+      }, "Application Name "), /*#__PURE__*/React.createElement("input", {
         type: "text",
         id: "app-name",
         name: "appName",
         value: this.state.appName,
         onChange: this.handleChange
-      }), /*#__PURE__*/React.createElement("br", null), /*#__PURE__*/React.createElement("label", {
+      }), /*#__PURE__*/React.createElement("br", null)), /*#__PURE__*/React.createElement("div", {
+        className: "form-input"
+      }, /*#__PURE__*/React.createElement("label", {
         htmlFor: "imageName"
-      }, "Image Name (leave blank to use the same name):"), /*#__PURE__*/React.createElement("input", {
+      }, "Image Name "), /*#__PURE__*/React.createElement("input", {
         type: "text",
         id: "image-name",
         name: "imageName",
         value: this.state.imageName,
+        placeholder: this.state.tempImageName,
         onChange: this.handleChange
-      }), /*#__PURE__*/React.createElement("br", null), /*#__PURE__*/React.createElement("label", {
+      }), /*#__PURE__*/React.createElement("br", null)), /*#__PURE__*/React.createElement("div", {
+        className: "form-input"
+      }, /*#__PURE__*/React.createElement("label", {
         htmlFor: "replicas"
-      }, "Number of containers to build:"), /*#__PURE__*/React.createElement("input", {
+      }, "Number of Containers "), /*#__PURE__*/React.createElement("input", {
         type: "number",
         id: "replicas",
         name: "replicas",
@@ -156,11 +172,14 @@ class DeployService extends React.Component {
         min: "1",
         max: "8",
         onChange: this.handleChange
-      }));
+      })));
     } else {
-      deployConfigGen = /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("label", {
+      deployConfigGen = /*#__PURE__*/React.createElement("div", {
+        className: "form-input"
+      }, /*#__PURE__*/React.createElement("label", {
+        className: "required-field",
         htmlFor: "deployConfigPath"
-      }, "Deployment Config Path:"), /*#__PURE__*/React.createElement("input", {
+      }, "Deployment Config Path "), /*#__PURE__*/React.createElement("input", {
         type: "text",
         id: "deploy-config-path",
         name: "deployConfigPath",
@@ -175,26 +194,32 @@ class DeployService extends React.Component {
       let networkConfigGen;
 
       if (this.state.useRepoDeployConfig) {
-        appConfigGen = /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("label", {
+        appConfigGen = /*#__PURE__*/React.createElement("div", {
+          className: "form-input"
+        }, /*#__PURE__*/React.createElement("label", {
+          className: "required-field",
           htmlFor: "appName"
-        }, "Application Name:"), /*#__PURE__*/React.createElement("input", {
+        }, "Application Name "), /*#__PURE__*/React.createElement("input", {
           type: "text",
           id: "app-name",
           name: "appName",
           value: this.state.appName,
           onChange: this.handleChange
-        }), /*#__PURE__*/React.createElement("br", null));
+        }));
       } else {
         appConfigGen = /*#__PURE__*/React.createElement("div", null);
       }
 
       if (this.state.openToNetwork) {
-        networkConfigGen = /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("label", {
+        networkConfigGen = /*#__PURE__*/React.createElement("div", {
+          className: "form-input"
+        }, /*#__PURE__*/React.createElement("label", {
           htmlFor: "nodePort"
-        }, "Network Port (must be between 30000-32767, leave blank for random):"), /*#__PURE__*/React.createElement("input", {
+        }, "Network Port "), /*#__PURE__*/React.createElement("input", {
           type: "text",
           id: "node-port",
           name: "nodePort",
+          placeholder: "30000-32767",
           value: this.state.nodePort,
           onChange: this.handleChange
         }));
@@ -202,9 +227,11 @@ class DeployService extends React.Component {
         networkConfigGen = /*#__PURE__*/React.createElement("div", null);
       }
 
-      serviceConfigGen = /*#__PURE__*/React.createElement("div", null, appConfigGen, /*#__PURE__*/React.createElement("label", {
+      serviceConfigGen = /*#__PURE__*/React.createElement("div", null, appConfigGen, /*#__PURE__*/React.createElement("div", {
+        className: "form-input"
+      }, /*#__PURE__*/React.createElement("label", {
         htmlFor: "netProtocol"
-      }, "Port Protocol:"), /*#__PURE__*/React.createElement("select", {
+      }, "Port Protocol "), /*#__PURE__*/React.createElement("select", {
         id: "net-protocol",
         name: "netProtocol",
         value: this.state.netProtocol,
@@ -215,32 +242,40 @@ class DeployService extends React.Component {
         value: "UDP"
       }, "UDP"), /*#__PURE__*/React.createElement("option", {
         value: "SCTP"
-      }, "SCTP")), /*#__PURE__*/React.createElement("br", null), /*#__PURE__*/React.createElement("label", {
+      }, "SCTP"))), /*#__PURE__*/React.createElement("div", {
+        className: "form-input"
+      }, /*#__PURE__*/React.createElement("label", {
+        className: "required-field",
         htmlFor: "containerPort"
-      }, "Container Port:"), /*#__PURE__*/React.createElement("input", {
+      }, "Container Port "), /*#__PURE__*/React.createElement("input", {
         type: "text",
         id: "container-port",
         name: "containerPort",
         value: this.state.containerPort,
         onChange: this.handleChange
-      }), /*#__PURE__*/React.createElement("br", null), /*#__PURE__*/React.createElement("input", {
+      }), /*#__PURE__*/React.createElement("br", null)), /*#__PURE__*/React.createElement("div", {
+        className: "form-input"
+      }, /*#__PURE__*/React.createElement("label", {
+        htmlFor: "openToNetwork"
+      }, "Open to port on network"), /*#__PURE__*/React.createElement("input", {
         type: "checkbox",
         id: "open-to-network",
         name: "openToNetwork",
         checked: this.state.openToNetwork,
         onChange: this.handleChange
-      }), /*#__PURE__*/React.createElement("label", {
-        htmlFor: "openToNetwork"
-      }, "Open to port on network"), /*#__PURE__*/React.createElement("br", null), networkConfigGen);
+      }), /*#__PURE__*/React.createElement("br", null)), networkConfigGen);
     } else {
-      serviceConfigGen = /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("label", {
+      serviceConfigGen = /*#__PURE__*/React.createElement("div", {
+        className: "form-input"
+      }, /*#__PURE__*/React.createElement("label", {
+        className: "required-field",
         htmlFor: "serviceConfigPath"
-      }, "Service Config Path:"), /*#__PURE__*/React.createElement("input", {
+      }, "Service Config Path "), /*#__PURE__*/React.createElement("input", {
         type: "text",
         id: "service-config-path",
         name: "serviceConfigPath",
-        value: this.state.serviceConfigPath,
         placeholder: "kaas.deploy.yaml",
+        value: this.state.serviceConfigPath,
         onChange: this.handleChange
       }));
     }
@@ -248,52 +283,67 @@ class DeployService extends React.Component {
     return /*#__PURE__*/React.createElement("div", {
       className: "content-wrapper",
       id: "deploy-service"
-    }, /*#__PURE__*/React.createElement("h2", null, "Deploy New Service"), /*#__PURE__*/React.createElement("form", {
+    }, /*#__PURE__*/React.createElement("h2", null, "Deploy New Service"), /*#__PURE__*/React.createElement("p", null, "Selections in red are required, the rest can be left blank to be generated."), /*#__PURE__*/React.createElement("form", {
       id: "deploy-form",
       onSubmit: this.handleSubmit
     }, /*#__PURE__*/React.createElement("h3", {
       className: "form-header"
-    }, "Image"), /*#__PURE__*/React.createElement("label", {
+    }, "Image"), /*#__PURE__*/React.createElement("div", {
+      className: "form-input"
+    }, /*#__PURE__*/React.createElement("label", {
+      className: "required-field",
       htmlFor: "repoUrl"
-    }, "GitHub Repository URL:"), /*#__PURE__*/React.createElement("input", {
+    }, "GitHub Repository URL "), /*#__PURE__*/React.createElement("input", {
       type: "text",
       id: "repo-url",
       name: "repoUrl",
       value: this.state.repoUrl,
       onChange: this.handleChange
-    }), /*#__PURE__*/React.createElement("br", null), /*#__PURE__*/React.createElement("label", {
+    }), /*#__PURE__*/React.createElement("br", null)), /*#__PURE__*/React.createElement("div", {
+      className: "form-input"
+    }, /*#__PURE__*/React.createElement("label", {
       htmlFor: "repoBranch"
-    }, "Repository Branch:"), /*#__PURE__*/React.createElement("input", {
+    }, "Repository Branch "), /*#__PURE__*/React.createElement("input", {
       type: "text",
       id: "repo-branch",
       name: "repoBranch",
       value: this.state.repoBranch,
       onChange: this.handleChange
-    }), /*#__PURE__*/React.createElement("br", null), /*#__PURE__*/React.createElement("h3", {
+    }), /*#__PURE__*/React.createElement("br", null)), /*#__PURE__*/React.createElement("h3", {
       className: "form-header"
-    }, "Deployment Configuration"), /*#__PURE__*/React.createElement("input", {
+    }, "Deployment Configuration"), /*#__PURE__*/React.createElement("div", {
+      className: "form-input"
+    }, /*#__PURE__*/React.createElement("label", {
+      htmlFor: "useRepoDeployConfig"
+    }, "Use repository K8s deployment config file"), /*#__PURE__*/React.createElement("input", {
       type: "checkbox",
       id: "use-repo-deploy-config",
       name: "useRepoDeployConfig",
       checked: this.state.useRepoDeployConfig,
       onChange: this.handleChange
-    }), /*#__PURE__*/React.createElement("label", {
-      htmlFor: "useRepoConfig"
-    }, "Use repository K8s deployment config file"), /*#__PURE__*/React.createElement("br", null), deployConfigGen, /*#__PURE__*/React.createElement("h3", {
+    }), /*#__PURE__*/React.createElement("br", null)), deployConfigGen, /*#__PURE__*/React.createElement("h3", {
       className: "form-header"
-    }, "Service Configuration"), /*#__PURE__*/React.createElement("input", {
+    }, "Service Configuration"), /*#__PURE__*/React.createElement("div", {
+      className: "form-input"
+    }, /*#__PURE__*/React.createElement("label", {
+      htmlFor: "useRepoServiceConfig"
+    }, "Use repository K8s service config file"), /*#__PURE__*/React.createElement("input", {
       type: "checkbox",
       id: "use-repo-service-config",
       name: "useRepoServiceConfig",
       checked: this.state.useRepoServiceConfig,
       onChange: this.handleChange
-    }), /*#__PURE__*/React.createElement("label", {
-      htmlFor: "useRepoConfig"
-    }, "Use repository K8s service config file"), /*#__PURE__*/React.createElement("br", null), serviceConfigGen, /*#__PURE__*/React.createElement("input", {
+    }), /*#__PURE__*/React.createElement("br", null)), serviceConfigGen, /*#__PURE__*/React.createElement("br", null), /*#__PURE__*/React.createElement("div", {
+      className: "form-input"
+    }, /*#__PURE__*/React.createElement("input", {
       type: "submit",
       id: "deploy-form-submit",
       value: "Deploy"
-    })));
+    }))), /*#__PURE__*/React.createElement("div", {
+      id: "overlay"
+    }), /*#__PURE__*/React.createElement("div", {
+      id: "modal"
+    }, "Deploying Service..."));
   }
 
 }
@@ -303,20 +353,23 @@ class ClusterManagement extends React.Component {
     return /*#__PURE__*/React.createElement("div", {
       className: "content-wrapper",
       id: "manage-services"
-    }, /*#__PURE__*/React.createElement("h2", null, "Manage services"), /*#__PURE__*/React.createElement("p", null, "Manage services not enabled yet"));
+    }, /*#__PURE__*/React.createElement("h2", null, "Manage services"), /*#__PURE__*/React.createElement("a", {
+      href: "https://dashboard.capstone.detjens.dev/",
+      target: "_blank"
+    }, "Connect to dashboard"));
   }
 
-}
+} // class AdminSettings extends React.Component {
+//     render() {
+//         return (
+//             <div className="content-wrapper" id="admin-settings">
+//                 <h2>Admin Settings</h2>
+//                 <p>Admin settings not enabled yet</p>
+//             </div>
+//         );
+//     }
+// }
 
-class AdminSettings extends React.Component {
-  render() {
-    return /*#__PURE__*/React.createElement("div", {
-      className: "content-wrapper",
-      id: "admin-settings"
-    }, /*#__PURE__*/React.createElement("h2", null, "Admin Settings"), /*#__PURE__*/React.createElement("p", null, "Admin settings not enabled yet"));
-  }
-
-}
 
 class Error404Page extends React.Component {
   render() {
@@ -346,9 +399,8 @@ class App extends React.Component {
     if (this.state.activeContent == "deploy-service") {
       content = /*#__PURE__*/React.createElement(DeployService, null);
     } else if (this.state.activeContent == "manage-services") {
-      content = /*#__PURE__*/React.createElement(ClusterManagement, null);
-    } else if (this.state.activeContent == "admin-settings") {
-      content = /*#__PURE__*/React.createElement(AdminSettings, null);
+      content = /*#__PURE__*/React.createElement(ClusterManagement, null); // } else if (this.state.activeContent == "admin-settings") {
+      //     content = <AdminSettings />
     } else {
       content = /*#__PURE__*/React.createElement(Error404Page, null);
     }

--- a/public/index.js
+++ b/public/index.js
@@ -116,6 +116,8 @@ class DeployService extends React.Component {
 
       if (!res.ok) {
         throw new Error("Status code " + res.status.toString() + " (" + res.statusText + ")\n" + JSON.stringify(body));
+      } else {
+        alert("Deployment created!");
       } //window.location.reload(true);
 
     } catch (error) {
@@ -126,7 +128,6 @@ class DeployService extends React.Component {
   render() {
     let deployConfigGen;
     let serviceConfigGen;
-    let networkConfigGen;
 
     if (!this.state.useRepoDeployConfig) {
       deployConfigGen = /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("label", {
@@ -168,22 +169,39 @@ class DeployService extends React.Component {
       }));
     }
 
-    if (this.state.openToNetwork) {
-      networkConfigGen = /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("label", {
-        htmlFor: "nodePort"
-      }, "Network Port (must be between 30000-32767, leave blank for random):"), /*#__PURE__*/React.createElement("input", {
-        type: "text",
-        id: "node-port",
-        name: "nodePort",
-        value: this.state.nodePort,
-        onChange: this.handleChange
-      }));
-    } else {
-      networkConfigGen = /*#__PURE__*/React.createElement("div", null);
-    }
-
     if (!this.state.useRepoServiceConfig) {
-      serviceConfigGen = /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("label", {
+      let appConfigGen;
+      let networkConfigGen;
+
+      if (this.state.useRepoDeployConfig) {
+        appConfigGen = /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("label", {
+          htmlFor: "appName"
+        }, "Application Name:"), /*#__PURE__*/React.createElement("input", {
+          type: "text",
+          id: "app-name",
+          name: "appName",
+          value: this.state.appName,
+          onChange: this.handleChange
+        }), /*#__PURE__*/React.createElement("br", null));
+      } else {
+        appConfigGen = /*#__PURE__*/React.createElement("div", null);
+      }
+
+      if (this.state.openToNetwork) {
+        networkConfigGen = /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("label", {
+          htmlFor: "nodePort"
+        }, "Network Port (must be between 30000-32767, leave blank for random):"), /*#__PURE__*/React.createElement("input", {
+          type: "text",
+          id: "node-port",
+          name: "nodePort",
+          value: this.state.nodePort,
+          onChange: this.handleChange
+        }));
+      } else {
+        networkConfigGen = /*#__PURE__*/React.createElement("div", null);
+      }
+
+      serviceConfigGen = /*#__PURE__*/React.createElement("div", null, appConfigGen, /*#__PURE__*/React.createElement("label", {
         htmlFor: "netProtocol"
       }, "Port Protocol:"), /*#__PURE__*/React.createElement("select", {
         id: "net-protocol",

--- a/public/index.js
+++ b/public/index.js
@@ -73,7 +73,7 @@ class DeployService extends React.Component {
     super(props);
     this.state = {
       repoUrl: '',
-      repoBranch: '',
+      repoBranch: 'main',
       useRepoDeployConfig: false,
       useRepoServiceConfig: false,
       deployConfigPath: '',
@@ -165,6 +165,7 @@ class DeployService extends React.Component {
         id: "deploy-config-path",
         name: "deployConfigPath",
         value: this.state.deployConfigPath,
+        placeholder: "kaas.deploy.yaml",
         onChange: this.handleChange
       }));
     }
@@ -239,6 +240,7 @@ class DeployService extends React.Component {
         id: "service-config-path",
         name: "serviceConfigPath",
         value: this.state.serviceConfigPath,
+        placeholder: "kaas.deploy.yaml",
         onChange: this.handleChange
       }));
     }

--- a/public/style.css
+++ b/public/style.css
@@ -7,6 +7,7 @@ body {
 
 h1 {
     font-size: 2.5em;
+    text-align: center;
 }
 
 h2 {
@@ -110,3 +111,39 @@ p {
     display: inline-block;
     margin: 0px 172px;
 }
+
+.form-input {
+    text-align: right;
+    padding: 5px 0px;
+}
+
+.required-field {
+    color: brown;
+    /* font-weight: bold; */
+}
+
+#overlay {
+    display: none;
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 100%;
+    z-index: 100;
+}
+
+#modal {
+    display: none;
+    position: fixed;
+    width: 300px;
+    height: 200px;
+    line-height: 200px;
+    top: 40%;
+    left: 50%;
+    margin-top: -100px;
+    margin-left: -150px;
+    background-color: lightblue;
+    text-align: center;
+    z-index: 101;
+}
+

--- a/server.js
+++ b/server.js
@@ -94,7 +94,7 @@ app.post('/deploy', async function (req, res) {
                         targetPort: parseInt(req.body.containerPort),
                         protocol: req.body.netProtocol
                     }],
-                    type: "NodeIP"
+                    type: "NodePort"
                 }
             };
             if (req.body.nodePort.toString() != '') {

--- a/server.js
+++ b/server.js
@@ -74,6 +74,7 @@ app.post('/deploy', async function (req, res) {
     }
 
     if (!req.body.useRepoServiceConfig) {
+        let projectName = req.body.appName.toString();
         if (req.body.openToNetwork) {
             reqBody.service_config = {
                 apiVersion: "v1",

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,8 +1,8 @@
-class LogoutButton extends React.Component {
+/*class LogoutButton extends React.Component {
     render() {
         return <button id="logout-button" name="logout" type="button">Logout</button>
     }
-}
+}*/
 
 
 class Header extends React.Component {
@@ -10,13 +10,15 @@ class Header extends React.Component {
         return (
             <div className="header">
                 <div className="title">
-                    <h1 className="title-text">[Name Pending]</h1>
+                    <h1 className="title-text">KubePi Pipeline</h1>
                 </div>
-                <div className="logout">
+                {/* <div className="logout">
                     <LogoutButton />
-                </div>
+                </div> */}
             </div>
         );
+
+        
     }
 }
 
@@ -37,7 +39,7 @@ class Sidebar extends React.Component {
                 <ul className="sidebar-list">
                     <li className="sidebar-tab"><button className={this.props.activeContent == "deploy-service" ? "active sidebar-option" : "sidebar-option"} id="deploy-service-button" name="deploy-service" type="button" onClick={this.handleClick}>Deploy New Service</button></li>
                     <li className="sidebar-tab"><button className={this.props.activeContent == "manage-services" ? "active sidebar-option" : "sidebar-option"} id="manage-services-button" name="manage-services" type="button" onClick={this.handleClick}>Manage Services</button></li>
-                    <li className="sidebar-tab"><button className={this.props.activeContent == "admin-settings" ? "active sidebar-option" : "sidebar-option"} id="admin-settings-button" name="admin-settings" type="button" onClick={this.handleClick}>Admin Settings</button></li>
+                    {/* <li className="sidebar-tab"><button className={this.props.activeContent == "admin-settings" ? "active sidebar-option" : "sidebar-option"} id="admin-settings-button" name="admin-settings" type="button" onClick={this.handleClick}>Admin Settings</button></li> */}
                 </ul>
             </div>
         );
@@ -56,7 +58,9 @@ class DeployService extends React.Component {
             deployConfigPath: '',
             serviceConfigPath: '',
             appName: '',
+            // tempAppName: '',
             imageName: '',
+            tempImageName: '',
             netProtocol: 'TCP',
             containerPort: '',
             openToNetwork: false,
@@ -73,6 +77,16 @@ class DeployService extends React.Component {
         const value = (target.type === 'checkbox' ? target.checked : target.value);
         const name = target.name;
 
+        
+        // if (name == "repoURL") {
+        //     newName = value.slice(19, value.length - 5);
+        //     this.setState({tempAppName: newName, tempImageName: newName + ":latest"});
+        // }
+        
+        if (name == "appName") {
+            this.setState({tempImageName: value + ":latest"});
+        }
+
         this.setState({
             [name]: value
         });
@@ -80,6 +94,17 @@ class DeployService extends React.Component {
 
     async handleSubmit(event) {
         event.preventDefault();
+
+        document.getElementById("overlay").style.display = "block";
+        document.getElementById("modal").style.display = "block";
+
+        // if (this.state.appName == '') {
+        //     this.setState({appName: this.state.tempAppName});
+        // }
+
+        // if (this.state.imageName == '') {
+        //     this.setState({imageName: this.state.tempImageName});
+        // }
 
         let url = window.location.href + 'deploy';
         let requestOptions = {
@@ -94,10 +119,14 @@ class DeployService extends React.Component {
             if (!res.ok) {
                 throw new Error("Status code " + res.status.toString() + " (" + res.statusText + ")\n" + JSON.stringify(body));
             } else {
-                alert("Deployment created!")
+                document.getElementById("overlay").style.display = "none";
+                document.getElementById("modal").style.display = "none";
+                alert("Deployment created!");
             }
             //window.location.reload(true);
         } catch (error) {
+            document.getElementById("overlay").style.display = "none";
+            document.getElementById("modal").style.display = "none";
             alert(error.message);
         }
     }
@@ -109,18 +138,24 @@ class DeployService extends React.Component {
         if (!this.state.useRepoDeployConfig) {
             deployConfigGen = (
                 <div>
-                    <label htmlFor="appName">Application Name:</label>
-                    <input type="text" id="app-name" name="appName" value={this.state.appName} onChange={this.handleChange} /><br/>
-                    <label htmlFor="imageName">Image Name (leave blank to use the same name):</label>
-                    <input type="text" id="image-name" name="imageName" value={this.state.imageName} onChange={this.handleChange} /><br/>
-                    <label htmlFor="replicas">Number of containers to build:</label>
-                    <input type="number" id="replicas" name="replicas" value={this.state.replicas} min="1" max="8" onChange={this.handleChange} />
+                    <div className="form-input">
+                        <label className="required-field" htmlFor="appName">Application Name </label>
+                        <input type="text" id="app-name" name="appName" value={this.state.appName} onChange={this.handleChange} /><br/>
+                    </div>
+                    <div className="form-input">
+                        <label htmlFor="imageName">Image Name </label>
+                        <input type="text" id="image-name" name="imageName" value={this.state.imageName} placeholder={this.state.tempImageName} onChange={this.handleChange} /><br/>
+                    </div>
+                    <div className="form-input">
+                        <label htmlFor="replicas">Number of Containers </label>
+                        <input type="number" id="replicas" name="replicas" value={this.state.replicas} min="1" max="8" onChange={this.handleChange} />
+                    </div>
                 </div>
             );
         } else {
             deployConfigGen = (
-                <div>
-                    <label htmlFor="deployConfigPath">Deployment Config Path:</label>
+                <div className="form-input">
+                    <label className="required-field" htmlFor="deployConfigPath">Deployment Config Path </label>
                     <input type="text" id="deploy-config-path" name="deployConfigPath" value={this.state.deployConfigPath} placeholder="kaas.deploy.yaml" onChange={this.handleChange} />
                 </div>
             );
@@ -132,9 +167,9 @@ class DeployService extends React.Component {
 
             if (this.state.useRepoDeployConfig) {
                 appConfigGen = (
-                    <div>
-                        <label htmlFor="appName">Application Name:</label>
-                        <input type="text" id="app-name" name="appName" value={this.state.appName} onChange={this.handleChange} /><br/>
+                    <div className="form-input">
+                        <label className="required-field" htmlFor="appName">Application Name </label>
+                        <input type="text" id="app-name" name="appName" value={this.state.appName} onChange={this.handleChange} />
                     </div>
                 );
 
@@ -145,9 +180,9 @@ class DeployService extends React.Component {
 
             if (this.state.openToNetwork) {
                 networkConfigGen = (
-                    <div>
-                        <label htmlFor="nodePort">Network Port (must be between 30000-32767, leave blank for random):</label>
-                        <input type="text" id="node-port" name="nodePort" value={this.state.nodePort} onChange={this.handleChange} />
+                    <div className="form-input">
+                        <label htmlFor="nodePort">Network Port </label>
+                        <input type="text" id="node-port" name="nodePort" placeholder="30000-32767" value={this.state.nodePort} onChange={this.handleChange} />
                     </div>
                 );
             } else {
@@ -157,24 +192,30 @@ class DeployService extends React.Component {
             serviceConfigGen = (
                 <div>
                     {appConfigGen}
-                    <label htmlFor="netProtocol">Port Protocol:</label>
-                    <select id="net-protocol" name="netProtocol" value={this.state.netProtocol} onChange={this.handleChange}>
-                        <option value="TCP">TCP</option>
-                        <option value="UDP">UDP</option>
-                        <option value="SCTP">SCTP</option>
-                    </select><br/>
-                    <label htmlFor="containerPort">Container Port:</label>
-                    <input type="text" id="container-port" name="containerPort" value={this.state.containerPort} onChange={this.handleChange} /><br/>
-                    <input type="checkbox" id="open-to-network" name="openToNetwork" checked={this.state.openToNetwork} onChange={this.handleChange} />
-                    <label htmlFor="openToNetwork">Open to port on network</label><br />
+                    <div className="form-input">
+                        <label htmlFor="netProtocol">Port Protocol </label>
+                        <select id="net-protocol" name="netProtocol" value={this.state.netProtocol} onChange={this.handleChange}>
+                            <option value="TCP">TCP</option>
+                            <option value="UDP">UDP</option>
+                            <option value="SCTP">SCTP</option>
+                        </select>
+                    </div>
+                    <div className="form-input">
+                        <label className="required-field" htmlFor="containerPort">Container Port </label>
+                        <input type="text" id="container-port" name="containerPort" value={this.state.containerPort} onChange={this.handleChange} /><br/>
+                    </div>
+                    <div className="form-input">
+                        <label htmlFor="openToNetwork">Open to port on network</label>
+                        <input type="checkbox" id="open-to-network" name="openToNetwork" checked={this.state.openToNetwork} onChange={this.handleChange} /><br/>
+                    </div>
                     {networkConfigGen}
                 </div>
             );
         } else {
             serviceConfigGen = (
-                <div>
-                    <label htmlFor="serviceConfigPath">Service Config Path:</label>
-                    <input type="text" id="service-config-path" name="serviceConfigPath" value={this.state.serviceConfigPath} placeholder="kaas.deploy.yaml" onChange={this.handleChange} />
+                <div className="form-input">
+                    <label className="required-field" htmlFor="serviceConfigPath">Service Config Path </label>
+                    <input type="text" id="service-config-path" name="serviceConfigPath" placeholder="kaas.deploy.yaml" value={this.state.serviceConfigPath} onChange={this.handleChange} />
                 </div>
             );
         }
@@ -182,22 +223,38 @@ class DeployService extends React.Component {
         return (
             <div className="content-wrapper" id="deploy-service">
                 <h2>Deploy New Service</h2>
+                <p>Selections in red are required, the rest can be left blank to be generated.</p>
                 <form id="deploy-form" onSubmit={this.handleSubmit}>
                     <h3 className="form-header">Image</h3>
-                    <label htmlFor="repoUrl">GitHub Repository URL:</label>
-                    <input type="text" id="repo-url" name="repoUrl" value={this.state.repoUrl} onChange={this.handleChange}/><br/>
-                    <label htmlFor="repoBranch">Repository Branch:</label>
-                    <input type="text" id="repo-branch" name="repoBranch" value={this.state.repoBranch} onChange={this.handleChange} /><br/>
+                    <div className="form-input">
+                        <label className="required-field" htmlFor="repoUrl">GitHub Repository URL </label>
+                        <input type="text" id="repo-url" name="repoUrl" value={this.state.repoUrl} onChange={this.handleChange}/><br/>
+                    </div>
+                    <div className="form-input">
+                        <label htmlFor="repoBranch">Repository Branch </label>
+                        <input type="text" id="repo-branch" name="repoBranch" value={this.state.repoBranch} onChange={this.handleChange} /><br/>
+                    </div>
                     <h3 className="form-header">Deployment Configuration</h3>
-                    <input type="checkbox" id="use-repo-deploy-config" name="useRepoDeployConfig" checked={this.state.useRepoDeployConfig} onChange={this.handleChange} />
-                    <label htmlFor="useRepoConfig">Use repository K8s deployment config file</label><br/>
+                    <div className="form-input">
+                        <label htmlFor="useRepoDeployConfig">Use repository K8s deployment config file</label>
+                        <input type="checkbox" id="use-repo-deploy-config" name="useRepoDeployConfig" checked={this.state.useRepoDeployConfig} onChange={this.handleChange} /><br/>
+                    </div>
                     {deployConfigGen}
                     <h3 className="form-header">Service Configuration</h3>
-                    <input type="checkbox" id="use-repo-service-config" name="useRepoServiceConfig" checked={this.state.useRepoServiceConfig} onChange={this.handleChange}/>
-                    <label htmlFor="useRepoConfig">Use repository K8s service config file</label><br/>
+                    <div className="form-input">
+                        <label htmlFor="useRepoServiceConfig">Use repository K8s service config file</label>
+                        <input type="checkbox" id="use-repo-service-config" name="useRepoServiceConfig" checked={this.state.useRepoServiceConfig} onChange={this.handleChange}/><br/>
+                    </div>
                     {serviceConfigGen}
-                    <input type="submit" id="deploy-form-submit" value="Deploy" />
+                    <br/>
+                    <div className="form-input">
+                        <input type="submit" id="deploy-form-submit" value="Deploy" />
+                    </div>
                 </form>
+                <div id="overlay"></div>
+                <div id="modal">
+                    Deploying Service...
+                </div>
             </div>
         );
     }
@@ -209,23 +266,23 @@ class ClusterManagement extends React.Component {
         return (
             <div className="content-wrapper" id="manage-services">
                 <h2>Manage services</h2>
-                <p>Manage services not enabled yet</p>
+                <a href="https://dashboard.capstone.detjens.dev/" target="_blank">Connect to dashboard</a>
             </div>
         );
     }
 }
 
 
-class AdminSettings extends React.Component {
-    render() {
-        return (
-            <div className="content-wrapper" id="admin-settings">
-                <h2>Admin Settings</h2>
-                <p>Admin settings not enabled yet</p>
-            </div>
-        );
-    }
-}
+// class AdminSettings extends React.Component {
+//     render() {
+//         return (
+//             <div className="content-wrapper" id="admin-settings">
+//                 <h2>Admin Settings</h2>
+//                 <p>Admin settings not enabled yet</p>
+//             </div>
+//         );
+//     }
+// }
 
 
 class Error404Page extends React.Component {
@@ -252,8 +309,8 @@ class App extends React.Component {
             content = <DeployService />
         } else if (this.state.activeContent == "manage-services") {
             content = <ClusterManagement />
-        } else if (this.state.activeContent == "admin-settings") {
-            content = <AdminSettings />
+        // } else if (this.state.activeContent == "admin-settings") {
+        //     content = <AdminSettings />
         } else {
             content = <Error404Page />
         }

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -93,6 +93,8 @@ class DeployService extends React.Component {
             let body = await res.json();
             if (!res.ok) {
                 throw new Error("Status code " + res.status.toString() + " (" + res.statusText + ")\n" + JSON.stringify(body));
+            } else {
+                alert("Deployment created!")
             }
             //window.location.reload(true);
         } catch (error) {
@@ -103,7 +105,6 @@ class DeployService extends React.Component {
     render() {
         let deployConfigGen;
         let serviceConfigGen;
-        let networkConfigGen;
 
         if (!this.state.useRepoDeployConfig) {
             deployConfigGen = (
@@ -125,21 +126,37 @@ class DeployService extends React.Component {
             );
         }
 
-
-        if (this.state.openToNetwork) {
-            networkConfigGen = (
-                <div>
-                    <label htmlFor="nodePort">Network Port (must be between 30000-32767, leave blank for random):</label>
-                    <input type="text" id="node-port" name="nodePort" value={this.state.nodePort} onChange={this.handleChange} />
-                </div>
-            );
-        } else {
-            networkConfigGen = <div></div>;
-        }
-
         if (!this.state.useRepoServiceConfig) {
+            let appConfigGen;
+            let networkConfigGen;
+
+            if (this.state.useRepoDeployConfig) {
+                appConfigGen = (
+                    <div>
+                        <label htmlFor="appName">Application Name:</label>
+                        <input type="text" id="app-name" name="appName" value={this.state.appName} onChange={this.handleChange} /><br/>
+                    </div>
+                );
+
+            } else {
+                appConfigGen = <div></div>;
+            }
+
+
+            if (this.state.openToNetwork) {
+                networkConfigGen = (
+                    <div>
+                        <label htmlFor="nodePort">Network Port (must be between 30000-32767, leave blank for random):</label>
+                        <input type="text" id="node-port" name="nodePort" value={this.state.nodePort} onChange={this.handleChange} />
+                    </div>
+                );
+            } else {
+                networkConfigGen = <div></div>;
+            }
+
             serviceConfigGen = (
                 <div>
+                    {appConfigGen}
                     <label htmlFor="netProtocol">Port Protocol:</label>
                     <select id="net-protocol" name="netProtocol" value={this.state.netProtocol} onChange={this.handleChange}>
                         <option value="TCP">TCP</option>

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -50,7 +50,7 @@ class DeployService extends React.Component {
         super(props);
         this.state = {
             repoUrl: '',
-            repoBranch: '',
+            repoBranch: 'main',
             useRepoDeployConfig: false,
             useRepoServiceConfig: false,
             deployConfigPath: '',
@@ -121,7 +121,7 @@ class DeployService extends React.Component {
             deployConfigGen = (
                 <div>
                     <label htmlFor="deployConfigPath">Deployment Config Path:</label>
-                    <input type="text" id="deploy-config-path" name="deployConfigPath" value={this.state.deployConfigPath} onChange={this.handleChange} />
+                    <input type="text" id="deploy-config-path" name="deployConfigPath" value={this.state.deployConfigPath} placeholder="kaas.deploy.yaml" onChange={this.handleChange} />
                 </div>
             );
         }
@@ -174,7 +174,7 @@ class DeployService extends React.Component {
             serviceConfigGen = (
                 <div>
                     <label htmlFor="serviceConfigPath">Service Config Path:</label>
-                    <input type="text" id="service-config-path" name="serviceConfigPath" value={this.state.serviceConfigPath} onChange={this.handleChange} />
+                    <input type="text" id="service-config-path" name="serviceConfigPath" value={this.state.serviceConfigPath} placeholder="kaas.deploy.yaml" onChange={this.handleChange} />
                 </div>
             );
         }


### PR DESCRIPTION
- Made Deployment config and Service config separate, so one can be in repo and other generated
- Added ability to make NodePort Service
- Simplified input with more autogen

Can be tested by running `npm start` in `~/website` on the Pi and connecting to [https://deploy.capstone.detjens.dev/](url). Currently, you must manually run the command robert provided to open the port up on [https://capstone.detjens.dev/](url) in order to actually access the pod from outside the Pi. Next steps include automating this.